### PR TITLE
add vcell local and remote messaging support for vcell integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,21 @@
             <version>${picocli.version}</version>
         </dependency>
         <dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>4.10.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/edu/uchc/cam/langevin/cli/RunCommand.java
+++ b/src/main/java/edu/uchc/cam/langevin/cli/RunCommand.java
@@ -1,10 +1,13 @@
 package edu.uchc.cam.langevin.cli;
 
+import com.google.gson.Gson;
 import edu.uchc.cam.langevin.langevinnovis01.Global;
 import edu.uchc.cam.langevin.langevinnovis01.MySystem;
+import org.vcell.messaging.*;
 import picocli.CommandLine;
 
 import java.io.File;
+import java.io.FileReader;
 import java.util.concurrent.Callable;
 
 @CommandLine.Command(name = "simulate", description = "Run a Langevin simulation.")
@@ -18,18 +21,55 @@ public class RunCommand implements Callable<Integer> {
     @CommandLine.Option(names = {"--output-log"}, required = false, type = File.class, description = "output log file")
     private File logFile = null;
 
+    private final String example_config = """
+                {
+                  "broker_host": "localhost",
+                  "broker_port": 8165,
+                  "broker_username": "msg_user",
+                  "broker_password": "msg_pswd",
+                  "compute_hostname": "localhost",
+                  "vc_username": "vcell_user",
+                  "simKey": "12334483837",
+                  "taskID": 0,
+                  "jobIndex": 0
+                }
+                """;
+    @CommandLine.Option(names = {"--vc-send-status-config"}, required = false, type = File.class,
+                        description = "json status message config file as:\n\n" + example_config)
+    private File sendStatusConfig = null;
+
+    @CommandLine.Option(names = {"--vc-print-status"}, required = false, type = Boolean.class, description = "print vcell status to stdout and stderr")
+    private boolean printStatus = false;
+
     public RunCommand() {
     }
 
     public Integer call() {
         Global g;
         MySystem sys;
+        VCellMessaging vcellMessaging = new VCellMessagingNoop();
+        if (sendStatusConfig != null) {
+            try {
+                // the messagingConfigFile is a json structure corresponding to a MessagingConfig object.
+                // create a MessagingConfig object by reading the messagingConfigFile
+                Gson gson = new Gson();
+                MessagingConfig messagingConfig = gson.fromJson(new FileReader(sendStatusConfig), MessagingConfig.class);
+                vcellMessaging = new VCellMessagingRest(messagingConfig);
+            } catch (Exception e) {
+                e.printStackTrace();
+                return 1;
+            }
+        } else if (printStatus) {
+            vcellMessaging = new VCellMessagingLocal();
+        } else {
+            vcellMessaging = new VCellMessagingNoop();
+        }
         if (logFile == null) {
             g = new Global(modelFile);
-            sys = new MySystem(g, runCounter, false);
+            sys = new MySystem(g, runCounter, false, vcellMessaging);
         } else {
             g = new Global(modelFile, logFile);
-            sys = new MySystem(g, runCounter, true);
+            sys = new MySystem(g, runCounter, true, vcellMessaging);
         }
 
         sys.runSystem();

--- a/src/main/java/edu/uchc/cam/langevin/g/object/GMolecule.java
+++ b/src/main/java/edu/uchc/cam/langevin/g/object/GMolecule.java
@@ -189,11 +189,7 @@ public class GMolecule {
     public void setAllInitialPositions(String [] xs, String [] ys, String [] zs){
         // <editor-fold defaultstate="collapsed" desc="Method Code">
         if(xs.length != ys.length || ys.length != zs.length){
-            System.out.println("Given unequal number of x,y,z initial positions.");
-            System.out.println("Given " + xs.length + " x ICs.");
-            System.out.println("Given " + ys.length + " y ICs.");
-            System.out.println("Given " + zs.length + " z ICs.");
-            System.exit(1);
+            throw new RuntimeException("Unequal number of x,y,z initial positions, xs="+xs.length+", ys="+ys.length+", zs="+zs.length);
         } else {
             try{
                 for(int i=0;i<xs.length;i++){
@@ -202,9 +198,7 @@ public class GMolecule {
                     zIC.add(Double.parseDouble(zs[i]));
                 }
             } catch(NumberFormatException nfe){
-                System.out.println("Could not interpret all initial conditions"
-                        + " as doubles.");
-                System.exit(1);
+                throw new RuntimeException("Could not interpret all initial conditions as doubles.", nfe);
             }
         }
         // </editor-fold>

--- a/src/main/java/edu/uchc/cam/langevin/langevinnovis01/Global.java
+++ b/src/main/java/edu/uchc/cam/langevin/langevinnovis01/Global.java
@@ -339,8 +339,7 @@ public class Global {
         try{
             br = new BufferedReader(new FileReader(file));
         } catch (FileNotFoundException e){
-            System.out.println("Error: The program could not find the specified file, " + filename + ", and will now abort.");
-            System.exit(1);
+            throw new RuntimeException("file " + filename + " not found");
         }
         
         Scanner sc = new Scanner(br);

--- a/src/main/java/org/vcell/messaging/MessagingConfig.java
+++ b/src/main/java/org/vcell/messaging/MessagingConfig.java
@@ -1,0 +1,13 @@
+package org.vcell.messaging;
+
+public record MessagingConfig(
+        String broker_host,
+        int broker_port,
+        String broker_username,
+        String broker_password,
+        String compute_hostname,
+        String vc_username,
+        String simKey,
+        int taskID,
+        int jobIndex
+) {}

--- a/src/main/java/org/vcell/messaging/VCellMessaging.java
+++ b/src/main/java/org/vcell/messaging/VCellMessaging.java
@@ -1,0 +1,6 @@
+package org.vcell.messaging;
+
+public interface VCellMessaging {
+    void sendWorkerEvent(WorkerEvent event);
+    void close();
+}

--- a/src/main/java/org/vcell/messaging/VCellMessagingLocal.java
+++ b/src/main/java/org/vcell/messaging/VCellMessagingLocal.java
@@ -1,0 +1,53 @@
+package org.vcell.messaging;
+
+import java.io.*;
+
+
+public class VCellMessagingLocal implements VCellMessaging {
+    private final BufferedWriter stdout_writer;
+    private final BufferedWriter stderr_writer;
+    
+    public VCellMessagingLocal() {
+        this(System.out, System.err);
+    } 
+    
+    // constructor - especially for testing
+    public VCellMessagingLocal(PrintStream stdout, PrintStream stderr) {
+        stdout_writer = new BufferedWriter(new PrintWriter(stdout));
+        stderr_writer = new BufferedWriter(new PrintWriter(stderr));
+    }
+    @Override
+    public void sendWorkerEvent(WorkerEvent event) {
+        try {
+            switch (event.status()) {
+                case JOB_DATA:
+                    stdout_writer.write("[[[data:"+event.timepoint()+"]]]\n");
+                    break;
+                case JOB_PROGRESS:
+                    stdout_writer.write("[[[progress:"+(event.progress() * 100.0)+"]]]\n");
+                    break;
+                case JOB_STARTING:
+                    stdout_writer.write(event.eventMessage() + "\n");
+                    break;
+                case JOB_COMPLETED:
+                    stderr_writer.write("Simulation Complete in Main() ...\n"); // out of band message
+                    break;
+                case JOB_FAILURE:
+                    stderr_writer.write(event.eventMessage()+"\n"); // out of band message
+                    break;
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void close() {
+        try {
+            stdout_writer.flush();
+            stderr_writer.flush();
+        } catch (IOException e) {
+            throw new RuntimeException("error closing output stream for log", e);
+        }
+    }
+}

--- a/src/main/java/org/vcell/messaging/VCellMessagingNoop.java
+++ b/src/main/java/org/vcell/messaging/VCellMessagingNoop.java
@@ -1,0 +1,11 @@
+package org.vcell.messaging;
+
+public class VCellMessagingNoop implements VCellMessaging {
+    @Override
+    public void sendWorkerEvent(WorkerEvent event) {
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/src/main/java/org/vcell/messaging/VCellMessagingRest.java
+++ b/src/main/java/org/vcell/messaging/VCellMessagingRest.java
@@ -1,0 +1,161 @@
+package org.vcell.messaging;
+
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+
+public class VCellMessagingRest implements VCellMessaging {
+
+
+    private final static String TIMETOLIVE_PROPERTY    = "JMSTimeToLive";
+    private final static String DELIVERYMODE_PROPERTY  = "JMSDeliveryMode";
+    private final static String DELIVERYMODE_PERSISTENT_VALUE = "persistent";
+    private final static String DELIVERYMODE_NONPERSISTENT_VALUE = "nonpersistent";
+    private final static String PRIORITY_PROPERTY      = "JMSPriority";
+    private final static String PRIORITY_DEFAULT_VALUE = "5";
+    private final static String MESSAGE_TYPE_PROPERTY	= "MessageType";
+    private final static String MESSAGE_TYPE_WORKEREVENT_VALUE	= "WorkerEvent";
+    private final static String USERNAME_PROPERTY = "UserName";
+    private final static String HOSTNAME_PROPERTY = "HostName";
+    private final static String SIMKEY_PROPERTY = "SimKey";
+    private final static String TASKID_PROPERTY	= "TaskID";
+    private final static String JOBINDEX_PROPERTY	= "JobIndex";
+    private final static String WORKEREVENT_STATUS = "WorkerEvent_Status";
+    private final static String WORKEREVENT_PROGRESS = "WorkerEvent_Progress";
+    private final static String WORKEREVENT_TIMEPOINT = "WorkerEvent_TimePoint";
+    private final static String WORKEREVENT_STATUSMSG = "WorkerEvent_StatusMsg";
+    private final static double WORKEREVENT_MESSAGE_MIN_TIME_SECONDS = 15.0;
+
+    private final static int ONE_SECOND = 1000;
+    private final static int ONE_MINUTE = 60 * ONE_SECOND;
+    private final static int DEFAULT_TTL_HIGH = 10 * ONE_MINUTE;
+    private final static int DEFAULT_TTL_LOW = ONE_MINUTE;
+
+
+
+    private final String m_broker_host_port; // hostname:8165
+    private final String m_vc_username;
+    private final String m_hostname;
+    private final String m_simKey;
+    private final int m_taskID;
+    private final int m_jobIndex;
+    private final long m_ttl_lowPriority = DEFAULT_TTL_LOW;
+    private final long m_ttl_highPriority = DEFAULT_TTL_HIGH;
+    private final String m_broker_username;
+    private final String m_broker_password;
+
+    // constructor
+    public VCellMessagingRest(MessagingConfig config) {
+        m_broker_host_port = config.broker_host() + ":" + config.broker_port();
+        m_broker_username = config.broker_username();
+        m_broker_password = config.broker_password();
+        m_vc_username = config.vc_username();
+        m_hostname = config.compute_hostname();
+        m_simKey = config.simKey();
+        m_taskID = config.taskID();
+        m_jobIndex = config.jobIndex();
+    }
+
+    @Override
+    public void sendWorkerEvent(WorkerEvent event) {
+        // make a REST call to the ActiveMQ server on it's rest port to send the event
+        // Documentation for the ActiveMQ restful API is missing, must see source code
+        //
+        // https://github.com/apache/activemq/blob/master/activemq-web/src/main/java/org/apache/activemq/web/MessageServlet.java
+        // https://github.com/apache/activemq/blob/master/activemq-web/src/main/java/org/apache/activemq/web/MessageServletSupport.java
+        //
+        // currently, the "web" api seems to use the same credentials as the "web console" ... defaults to admin:admin.
+        // TODO: pass in credentials, and protect them better (consider HTTPS).
+        //
+        /*
+            PROPERTIES="JMSDeliveryMode=persistent&JMSTimeToLive=3000"
+            PROPERTIES="${PROPERTIES}&SimKey=12446271133&JobIndex=0&TaskID=0&UserName=schaff"
+            PROPERTIES="${PROPERTIES}&MessageType=WorkerEvent&WorkerEvent_Status=1001&WorkerEvent_StatusMsg=Running"
+            PROPERTIES="${PROPERTIES}&WorkerEvent_TimePoint=2.0&WorkerEvent_Progress=0.4&HostName=localhost"
+            curl -XPOST "http://msg_user:msg_pswd@`hostname`:8165/api/message/workerEvent?type=queue&${PROPERTIES}"
+        */
+        StringBuilder ss_url = new StringBuilder();
+
+        // ss_url.append("http://" << m_smqusername << ":" << m_password << "@" << m_broker << "/api/message/workerEvent?type=queue&";
+        ss_url.append("http://"+m_broker_username+":"+m_broker_password+"@").append(m_broker_host_port).append("/api/message/workerEvent?type=queue&");
+
+        switch (event.status()) {
+            case JOB_DATA:
+                ss_url.append(PRIORITY_PROPERTY).append("=").append(PRIORITY_DEFAULT_VALUE).append("&");
+                ss_url.append(TIMETOLIVE_PROPERTY).append("=").append(m_ttl_lowPriority).append("&");
+                ss_url.append(DELIVERYMODE_PROPERTY).append("=").append(DELIVERYMODE_NONPERSISTENT_VALUE).append("&");
+                break;
+            case JOB_PROGRESS:
+                ss_url.append(PRIORITY_PROPERTY).append("=").append(PRIORITY_DEFAULT_VALUE).append("&");
+                ss_url.append(TIMETOLIVE_PROPERTY).append("=").append(m_ttl_lowPriority).append("&");
+                ss_url.append(DELIVERYMODE_PROPERTY).append("=").append(DELIVERYMODE_NONPERSISTENT_VALUE).append("&");
+                break;
+            case JOB_STARTING:
+                ss_url.append(PRIORITY_PROPERTY).append("=").append(PRIORITY_DEFAULT_VALUE).append("&");
+                ss_url.append(TIMETOLIVE_PROPERTY).append("=").append(m_ttl_highPriority).append("&");
+                ss_url.append(DELIVERYMODE_PROPERTY).append("=").append(DELIVERYMODE_PERSISTENT_VALUE).append("&");
+                break;
+            case JOB_COMPLETED:
+                ss_url.append(PRIORITY_PROPERTY).append("=").append(PRIORITY_DEFAULT_VALUE).append("&");
+                ss_url.append(TIMETOLIVE_PROPERTY).append("=").append(m_ttl_highPriority).append("&");
+                ss_url.append(DELIVERYMODE_PROPERTY).append("=").append(DELIVERYMODE_PERSISTENT_VALUE).append("&");
+                break;
+            case JOB_FAILURE:
+                ss_url.append(PRIORITY_PROPERTY).append("=").append(PRIORITY_DEFAULT_VALUE).append("&");
+                ss_url.append(TIMETOLIVE_PROPERTY).append("=").append(m_ttl_highPriority).append("&");
+                ss_url.append(DELIVERYMODE_PROPERTY).append("=").append(DELIVERYMODE_PERSISTENT_VALUE).append("&");
+                break;
+        }
+
+        ss_url.append(MESSAGE_TYPE_PROPERTY).append("=").append(MESSAGE_TYPE_WORKEREVENT_VALUE).append("&");
+        ss_url.append(USERNAME_PROPERTY).append("=").append(m_vc_username).append("&");
+        ss_url.append(HOSTNAME_PROPERTY).append("=").append(m_hostname).append("&");
+        ss_url.append(SIMKEY_PROPERTY).append("=").append(m_simKey).append("&");
+        ss_url.append(TASKID_PROPERTY).append("=").append(m_taskID).append("&");
+        ss_url.append(JOBINDEX_PROPERTY).append("=").append(m_jobIndex).append("&");
+
+        ss_url.append(WORKEREVENT_STATUS).append("=").append(event.status()).append("&");
+
+        String revisedMsg = event.eventMessage();
+        if (revisedMsg != null && !revisedMsg.isEmpty()) {
+            revisedMsg = revisedMsg.trim();
+            if (revisedMsg.length() > 2048) {
+                revisedMsg = revisedMsg.substring(0, 2048); //status message is only 2048 chars long in database
+            }
+            // these characters are not valid both in database and in messages as a property
+            revisedMsg = revisedMsg.replaceAll("[\n\r'\"]", " ");
+            revisedMsg = URLEncoder.encode(revisedMsg, StandardCharsets.UTF_8);
+            ss_url.append(WORKEREVENT_STATUSMSG).append("=").append(revisedMsg).append("&");
+        }
+
+        ss_url.append(WORKEREVENT_PROGRESS).append("=").append(event.progress()).append("&");
+        ss_url.append(WORKEREVENT_TIMEPOINT).append("=").append(event.timepoint());
+
+        System.out.println("URL: " + ss_url.toString());
+        URI uri = URI.create(ss_url.toString());
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(uri)
+                .POST(HttpRequest.BodyPublishers.ofString(""))
+                .build();
+        try {
+            // send the request
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            System.out.println(response.statusCode());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+
+    @Override
+    public void close() {
+        // not needed, HTTP is connectionless
+    }
+}

--- a/src/main/java/org/vcell/messaging/WorkerEvent.java
+++ b/src/main/java/org/vcell/messaging/WorkerEvent.java
@@ -1,0 +1,27 @@
+package org.vcell.messaging;
+
+public record WorkerEvent(
+        WorkerStatus status,
+        double progress,
+        double timepoint,
+        String eventMessage
+) {
+    public static WorkerEvent dataEvent(double timepoint) {
+        return new WorkerEvent(WorkerStatus.JOB_DATA, 0.0, timepoint, "");
+    }
+    public static WorkerEvent progressEvent(double progress) {
+        return new WorkerEvent(WorkerStatus.JOB_PROGRESS, progress, 0.0, "");
+    }
+    public static WorkerEvent startingEvent(String eventMessage) {
+        return new WorkerEvent(WorkerStatus.JOB_STARTING, 0.0, 0.0, eventMessage);
+    }
+    public static WorkerEvent completedEvent() {
+        return new WorkerEvent(WorkerStatus.JOB_COMPLETED, 0.0, 0.0, "");
+    }
+    public static WorkerEvent failureEvent(String eventMessage) {
+        return new WorkerEvent(WorkerStatus.JOB_FAILURE, 0.0, 0.0, eventMessage);
+    }
+    public static WorkerEvent workerAliveEvent() {
+        return new WorkerEvent(WorkerStatus.JOB_WORKER_ALIVE, 0.0, 0.0, "");
+    }
+}

--- a/src/main/java/org/vcell/messaging/WorkerStatus.java
+++ b/src/main/java/org/vcell/messaging/WorkerStatus.java
@@ -1,0 +1,16 @@
+package org.vcell.messaging;
+
+public enum WorkerStatus {
+    JOB_STARTING(999),
+    JOB_DATA(1000),
+    JOB_PROGRESS(1001),
+    JOB_FAILURE(1002),
+    JOB_COMPLETED(1003),
+    JOB_WORKER_ALIVE(1004);
+
+    public final int status;
+
+    WorkerStatus(int status) {
+        this.status = status;
+    }
+}

--- a/src/test/java/org/vcell/messaging/VCellMessagingLocalTest.java
+++ b/src/test/java/org/vcell/messaging/VCellMessagingLocalTest.java
@@ -1,0 +1,105 @@
+package org.vcell.messaging;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+public class VCellMessagingLocalTest {
+
+    PrintStream stdout;
+    ByteArrayOutputStream boas_stdout;
+    PrintStream stderr;
+    ByteArrayOutputStream boas_stderr;
+
+    @BeforeEach
+    public void setUp() {
+        boas_stdout = new ByteArrayOutputStream();
+        stdout = new PrintStream(boas_stdout);
+        boas_stderr = new ByteArrayOutputStream();
+        stderr = new PrintStream(boas_stderr);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        boas_stdout.reset();
+        boas_stderr.reset();
+    }
+
+    private String getStdout() {
+        return boas_stdout.toString();
+    }
+
+    private String getStderr() {
+        return boas_stderr.toString();
+    }
+
+    @Test
+    public void testVCellMessagingLocal_normal() {
+        VCellMessagingLocal vcellMessaging = new VCellMessagingLocal(stdout, stderr);
+
+        // test sendWorkerEvent
+        vcellMessaging.sendWorkerEvent(WorkerEvent.startingEvent("Starting Job"));
+        vcellMessaging.sendWorkerEvent(WorkerEvent.dataEvent(0.0));
+        vcellMessaging.sendWorkerEvent(WorkerEvent.progressEvent(0.0));
+        vcellMessaging.sendWorkerEvent(WorkerEvent.dataEvent(1.0));
+        vcellMessaging.sendWorkerEvent(WorkerEvent.progressEvent(0.5));
+        vcellMessaging.sendWorkerEvent(WorkerEvent.dataEvent(2.0));
+        vcellMessaging.sendWorkerEvent(WorkerEvent.progressEvent(1.0));
+        vcellMessaging.sendWorkerEvent(WorkerEvent.completedEvent());
+
+        vcellMessaging.close(); // flush the buffers
+
+        // compare the stdout to the expected stdout
+        String expected_stdout = """
+                Starting Job
+                [[[data:0.0]]]
+                [[[progress:0.0]]]
+                [[[data:1.0]]]
+                [[[progress:50.0]]]
+                [[[data:2.0]]]
+                [[[progress:100.0]]]
+                """;
+        Assertions.assertEquals(expected_stdout, getStdout());
+
+        // compare the stderr to the expected stderr
+        String expected_stderr = """
+                Simulation Complete in Main() ...
+                """;
+        Assertions.assertEquals(expected_stderr, getStderr());
+    }
+
+    @Test
+    public void testVCellMessagingLocal_failure() {
+        VCellMessagingLocal vcellMessaging = new VCellMessagingLocal(stdout, stderr);
+
+        // test sendWorkerEvent
+        vcellMessaging.sendWorkerEvent(WorkerEvent.startingEvent("Starting Job"));
+        vcellMessaging.sendWorkerEvent(WorkerEvent.dataEvent(0.0));
+        vcellMessaging.sendWorkerEvent(WorkerEvent.progressEvent(0.0));
+        vcellMessaging.sendWorkerEvent(WorkerEvent.dataEvent(1.0));
+        vcellMessaging.sendWorkerEvent(WorkerEvent.progressEvent(0.5));
+        vcellMessaging.sendWorkerEvent(WorkerEvent.failureEvent("Failure"));
+
+        vcellMessaging.close(); // flush the buffers
+
+        // compare the stdout to the expected stdout
+        String expected_stdout = """
+                Starting Job
+                [[[data:0.0]]]
+                [[[progress:0.0]]]
+                [[[data:1.0]]]
+                [[[progress:50.0]]]
+                """;
+        Assertions.assertEquals(expected_stdout, getStdout());
+
+        // compare the stderr to the expected stderr
+        String expected_stderr = """
+                Failure
+                """;
+        Assertions.assertEquals(expected_stderr, getStderr());
+    }
+}

--- a/src/test/java/org/vcell/messaging/VCellMessagingRestTest.java
+++ b/src/test/java/org/vcell/messaging/VCellMessagingRestTest.java
@@ -1,0 +1,115 @@
+package org.vcell.messaging;
+
+import com.google.gson.Gson;
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.FileReader;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class VCellMessagingRestTest {
+    private MockWebServer mockWebServer;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    public void testSendWorkerEvent_starting() throws Exception {
+        // Arrange
+        mockWebServer.enqueue(new MockResponse().setBody("OK"));
+
+        HttpUrl url = mockWebServer.url("/");
+
+        MessagingConfig config = new MessagingConfig (
+                url.host(),
+                url.port(),
+                "msg_user",
+                "msg_pswd",
+                "localhost",
+                "schaff",
+                "12334483837",
+                0,
+                0
+                );
+
+        VCellMessagingRest vCellMessagingRest = new VCellMessagingRest(config);
+
+        String expectedPath =
+                "/api/message/workerEvent" +
+                        "?type=queue" +
+                        "&JMSPriority=5" +
+                        "&JMSTimeToLive=600000" +
+                        "&JMSDeliveryMode=persistent" +
+                        "&MessageType=WorkerEvent" +
+                        "&UserName=schaff" +
+                        "&HostName=localhost" +
+                        "&SimKey=12334483837" +
+                        "&TaskID=0" +
+                        "&JobIndex=0" +
+                        "&WorkerEvent_Status=JOB_STARTING" +
+                        "&WorkerEvent_StatusMsg=Starting+Job" +
+                        "&WorkerEvent_Progress=0.0" +
+                        "&WorkerEvent_TimePoint=0.0";
+
+        vCellMessagingRest.sendWorkerEvent(WorkerEvent.startingEvent("Starting Job"));
+
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertEquals("POST", request.getMethod());
+        assertEquals(expectedPath, request.getPath());
+        assertEquals("", request.getBody().readUtf8());
+    }
+
+    @Test
+    public void testMessagingConfig() {
+        MessagingConfig config = new MessagingConfig(
+                "localhost",
+                8165,
+                "msg_user",
+                "msg_pswd",
+                "localhost",
+                "schaff",
+                "12334483837",
+                0,
+                0
+        );
+
+        Gson gson = new Gson();
+        String json_formatted = """
+                {
+                  "broker_host": "localhost",
+                  "broker_port": 8165,
+                  "broker_username": "msg_user",
+                  "broker_password": "msg_pswd",
+                  "compute_hostname": "localhost",
+                  "vc_username": "schaff",
+                  "simKey": "12334483837",
+                  "taskID": 0,
+                  "jobIndex": 0
+                }
+                """;
+        MessagingConfig config2 = gson.fromJson(json_formatted, MessagingConfig.class);
+
+        // test the parsed json is equal to the original config
+        assertEquals(config, config2);
+
+        // test that round-tripping to json and back results in the same object
+        String generated_json = gson.toJson(config);
+        MessagingConfig reconstituted_config = gson.fromJson(generated_json, MessagingConfig.class);
+        assertEquals(config, reconstituted_config);
+    }
+}


### PR DESCRIPTION
A VCellMessaging interface provides for sending WorkerEvents (status/progress) to stdout/stderr or to a messaging server.

The MessagingConfig class is used to hold the configuration for messaging, including broker host, port, username, password, compute hostname, vcell username, simKey, taskID, and jobIndex. The MessagingConfig is read from a json file passed into the solver.

```
Usage: langevin simulate [--vc-print-status] [--output-log=<logFile>]
                         [--vc-send-status-config=<sendStatusConfig>]
                         <modelFile> <runCounter>
Run a Langevin simulation.
      <modelFile>         Langevin model file
      <runCounter>        run counter
      --output-log=<logFile>
                          output log file
      --vc-print-status   print vcell status to stdout and stderr
      --vc-send-status-config=<sendStatusConfig>
                          json status message config file as:

                          {
                            "broker_host": "localhost",
                            "broker_port": 8165,
                            "broker_username": "msg_user",
                            "broker_password": "msg_pswd",
                            "compute_hostname": "localhost",
                            "vc_username": "vcell_user",
                            "simKey": "12334483837",
                            "taskID": 0,
                            "jobIndex": 0
                          }
```