### PR TITLE
Json serialization bug

### DIFF
--- a/src/main/java/org/vcell/data/EnvCheck.java
+++ b/src/main/java/org/vcell/data/EnvCheck.java
@@ -1,0 +1,37 @@
+package org.vcell.data;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class EnvCheck {
+
+    public static void main(String[] args) {
+        System.out.println("==== Java Environment Diagnostic ====");
+
+        System.out.println("java.version          = " + System.getProperty("java.version"));
+        System.out.println("java.runtime.name     = " + System.getProperty("java.runtime.name"));
+        System.out.println("java.vm.name          = " + System.getProperty("java.vm.name"));
+        System.out.println("java.vendor           = " + System.getProperty("java.vendor"));
+        System.out.println("os.name               = " + System.getProperty("os.name"));
+
+        // Check if running inside a GraalVM native image
+        try {
+            boolean inImage = Class.forName("org.graalvm.nativeimage.ImageInfo")
+                    .getMethod("inImageCode")
+                    .invoke(null)
+                    .equals(Boolean.TRUE);
+            System.out.println("Detected GraalVM native image runtime = " + inImage);
+        } catch (Exception e) {
+            System.out.println("Not running as a native image (no org.graalvm.nativeimage.ImageInfo available)");
+        }
+
+        // Bonus: Check Jackson's take on your class
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            System.out.println("Attempting to introspect: TimePointClustersInfo");
+            System.out.println(mapper.writerWithDefaultPrettyPrinter()
+                    .writeValueAsString(new org.vcell.data.LangevinPostprocessor.TimePointClustersInfo()));
+        } catch (Exception e) {
+            System.out.println("Jackson failed to serialize: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/org/vcell/data/LangevinPostprocessor.java
+++ b/src/main/java/org/vcell/data/LangevinPostprocessor.java
@@ -183,6 +183,13 @@ public class LangevinPostprocessor {
 
         @JsonProperty("timePointClusterInfoList")
         public List<ClusterInfo> timePointClusterInfoList = new ArrayList<>(); // non trivial clusters for this timepoint
+
+        public int getTimePointTotalClusters() {
+            return timePointTotalClusters;
+        }
+        public List<ClusterInfo> getTimePointClusterInfoList() {
+            return timePointClusterInfoList;
+        }
     }
     public static class ClusterInfo implements Serializable {  // info on a non-trivial cluster (2 molecules or more)
         private static final long serialVersionUID = 1L;
@@ -195,6 +202,10 @@ public class LangevinPostprocessor {
 
         @JsonProperty("clusterComponents")
         Map<String, Integer> clusterComponents = new LinkedHashMap<>(); // key = molecule name, value = number of molecules in the cluster
+
+        public int getClusterIndex() { return clusterIndex; }
+        public int getSize() { return size; }
+        public Map<String, Integer> getClusterComponents() { return clusterComponents; }
     }
 
     private static Map<String, Integer> getMolecules(Path langevinOutputDir) throws IOException {

--- a/src/main/java/org/vcell/data/LangevinPostprocessor.java
+++ b/src/main/java/org/vcell/data/LangevinPostprocessor.java
@@ -190,6 +190,8 @@ public class LangevinPostprocessor {
         public List<ClusterInfo> getTimePointClusterInfoList() {
             return timePointClusterInfoList;
         }
+        public void setTimePointTotalClusters(int total) { this.timePointTotalClusters = total; }
+        public void setTimePointClusterInfoList(List<ClusterInfo> list) { this.timePointClusterInfoList = list; }
     }
     public static class ClusterInfo implements Serializable {  // info on a non-trivial cluster (2 molecules or more)
         private static final long serialVersionUID = 1L;
@@ -206,6 +208,16 @@ public class LangevinPostprocessor {
         public int getClusterIndex() { return clusterIndex; }
         public int getSize() { return size; }
         public Map<String, Integer> getClusterComponents() { return clusterComponents; }
+
+        public void setClusterIndex(int clusterIndex) {
+            this.clusterIndex = clusterIndex;
+        }
+        public void setSize(int size) {
+            this.size = size;
+        }
+        public void setClusterComponents(Map<String, Integer> clusterComponents) {
+            this.clusterComponents = clusterComponents;
+        }
     }
 
     private static Map<String, Integer> getMolecules(Path langevinOutputDir) throws IOException {


### PR DESCRIPTION
No serializer found for class org.vcell.data.LangevinPostprocessor$TimePointClustersInfo and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS). This appears to be a native image, in which case you may need to configure reflection for the class that is to be serialized (through reference chain: java.util.LinkedHashMap["timePointClustersInfo"])