### PR TITLE
Fixed image runtime error with GraalVM by providing reflection metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,7 @@
                             <fallback>false</fallback>
                             <buildArgs>
                                 <arg>--initialize-at-build-time=edu.uchc.cam.langevin.cli.Version --no-fallback -H:DashboardDump=fortune -H:+DashboardAll</arg>
+                                <arg>-H:ConfigurationFileDirectories=src/main/resources</arg>
                             </buildArgs>
                         </configuration>
                     </plugin>
@@ -226,6 +227,7 @@
                             <fallback>false</fallback>
                             <buildArgs>
                                 <arg>--static --libc=musl --initialize-at-build-time=edu.uchc.cam.langevin.cli.Version --no-fallback -H:DashboardDump=fortune -H:+DashboardAll</arg>
+                                <arg>-H:ConfigurationFileDirectories=src/main/resources</arg>
                             </buildArgs>
                         </configuration>
                     </plugin>

--- a/src/main/resources/reflect-config.json
+++ b/src/main/resources/reflect-config.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "org.vcell.data.LangevinPostprocessor$TimePointClustersInfo",
+    "allDeclaredFields": true,
+    "allPublicMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "org.vcell.data.LangevinPostprocessor$ClusterInfo",
+    "allDeclaredFields": true,
+    "allPublicMethods": true,
+    "allDeclaredConstructors": true
+  }
+]


### PR DESCRIPTION
Runtime error:
This appears to be a native image, in which case you may need to configure reflection for the class that is to be serialized (through reference chain: java.util.LinkedHashMap["timePointClustersInfo"])