### PR TITLE
avoid re-runs when editing release metadata

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,7 +1,7 @@
 name: CD
 on:
   release:
-    types: [published, edited]
+    types: [published]
   workflow_dispatch:    # manual trigger for testing
 
 jobs:


### PR DESCRIPTION
Rerunning a workflow on an existing release cannot overwrite assets.
Once a release contains assets, GitHub refuses any upload with the same name.
CD fails with an unhelpful:
Validation Failed

Fixes #35