### PR TITLE
Fix NullPointerException when a bound site transitions to a state with no defined binding reaction

### DIFF
--- a/src/main/java/edu/uchc/cam/langevin/reaction/AllostericReactions.java
+++ b/src/main/java/edu/uchc/cam/langevin/reaction/AllostericReactions.java
@@ -108,9 +108,14 @@ public class AllostericReactions {
         String id = Integer.toString(site.getState().getID());
         String partnerID = Integer.toString(site.getBindingPartner().getState().getID());
         Bond bond = site.getBond();
-        bond.setReactionName(bindingReactions.getName(id, partnerID));
+        if(bindingReactions.getName(id, partnerID) != null) {
+            bond.setReactionName(bindingReactions.getName(id, partnerID));
+        }
         bond.setOffProbability(bindingReactions.getOffProb(id, partnerID));
-        bond.setBondLength(bindingReactions.getBondLength(id, partnerID));
+        Double bondLength = bindingReactions.getBondLength(id, partnerID);
+        if (bondLength != null) {
+            bond.setBondLength(bondLength);
+        }
     }
     
 }

--- a/src/main/java/edu/uchc/cam/langevin/reaction/BindingReactions.java
+++ b/src/main/java/edu/uchc/cam/langevin/reaction/BindingReactions.java
@@ -208,7 +208,7 @@ public class BindingReactions {
         return reactionNames.get(key1+key2);
     }
 
-    public double getBondLength(String key1, String key2){
+    public Double getBondLength(String key1, String key2){
         return bondLengths.get(key1+key2);
     }
 

--- a/src/main/java/edu/uchc/cam/langevin/reaction/TransitionReactions.java
+++ b/src/main/java/edu/uchc/cam/langevin/reaction/TransitionReactions.java
@@ -73,7 +73,6 @@ public class TransitionReactions {
                     break;
                 }
                 switch(reaction.getConditionID()){
-                    
                     // If there is no condition, then just try the reaction
                     case GTransitionReaction.NONE:{
                         if(reactionOccurs(reaction.getRate())){
@@ -85,7 +84,6 @@ public class TransitionReactions {
                         }
                         break;
                     }
-                
                     // Now try the reactions with unbound (free) conditions
                     case GTransitionReaction.FREE:{
                         if(!site.isBound()){
@@ -96,7 +94,6 @@ public class TransitionReactions {
                         }
                         break;
                     }
-                    
                     // Now try the reactions which only occur when a site is bound
                     case GTransitionReaction.BOUND:{
                         if(site.isBound()){

--- a/src/main/java/edu/uchc/cam/langevin/reaction/TransitionReactions.java
+++ b/src/main/java/edu/uchc/cam/langevin/reaction/TransitionReactions.java
@@ -121,21 +121,29 @@ public class TransitionReactions {
                         }
                         break;
                     }
-                    
                     default:
                         // Do nothing
                 }
             }
         }
     }
-    
+
+    // we changed the state of a site that is part of the bond
+    // there may be another binding reaction for which this complex is now a participant
+    // if there isn't any, we keep the same bond type (which is a lie, but it is better than using a null reaction name
+    // which would crash the counter logic)
     private void updateBondType(Site site){
         String id = Integer.toString(site.getState().getID());
         String partnerID = Integer.toString(site.getBindingPartner().getState().getID());
         Bond bond = site.getBond();
-        bond.setReactionName(bindingReactions.getName(id, partnerID));
+        if(bindingReactions.getName(id, partnerID) != null) {
+            bond.setReactionName(bindingReactions.getName(id, partnerID));
+        }
         bond.setOffProbability(bindingReactions.getOffProb(id, partnerID));
-        bond.setBondLength(bindingReactions.getBondLength(id, partnerID));
+        Double bondLength = bindingReactions.getBondLength(id, partnerID);
+        if (bondLength != null) {
+            bond.setBondLength(bondLength);
+        }
     }
     
     private boolean reactionOccurs(double rate){

--- a/src/test/java/edu/uchc/cam/langevin/langevinnovis01/MySystemTest.java
+++ b/src/test/java/edu/uchc/cam/langevin/langevinnovis01/MySystemTest.java
@@ -212,4 +212,44 @@ public class MySystemTest {
         }
     }
 
+    // do not run on github actions, it's somewhat long
+    @DisabledIfEnvironmentVariable(named = "GITHUB_ACTIONS", matches = "true")
+    @Test
+    public void routineDebuggingFromResource() throws IOException {
+        String sim_base_name = "sim";
+        int runCounter = 0;
+
+        // Load the real file from src/test/resources
+        String inputFileContents;
+        try (InputStream is = getClass().getResourceAsStream("/TransitionCondBound.ssld")) {
+            assertNotNull(is, "Resource TransitionCondBound.ssld not found");
+            inputFileContents = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+        }
+
+        Path tempDirectory = Files.createTempDirectory("test_simulation");
+        Path modelFile = tempDirectory.resolve(sim_base_name + ".langevinInput");
+        Path logFile = tempDirectory.resolve(sim_base_name + ".log");
+        Path idaFile = tempDirectory.resolve(sim_base_name + ".ida");
+
+        Files.writeString(modelFile, inputFileContents);
+
+        VCellMessaging vcellMessaging = new VCellMessagingLocal();
+        Global g = null;
+        MySystem sys = null;
+
+        try {
+            g = new Global(modelFile.toFile(), logFile.toFile());
+            assertNotNull(g, "Global object should not be null");
+
+            sys = new MySystem(g, runCounter, true, vcellMessaging);
+            assertNotNull(sys, "MySystem object should not be null");
+
+            sys.runSystem();
+            Assertions.assertTrue(Files.exists(idaFile));
+
+        } finally {
+            deleteDirectory(tempDirectory.toFile());
+        }
+    }
+
 }

--- a/src/test/resources/TransitionCondBound.ssld
+++ b/src/test/resources/TransitionCondBound.ssld
@@ -1,0 +1,103 @@
+*** TIME INFORMATION ***
+Total time: 0.01
+dt: 1.0E-8
+dt_data: 1.0E-4
+dt_spring: 1.0E-9
+dt_image: 1.0E-4
+
+*** SYSTEM INFORMATION ***
+L_x: 0.1
+L_y: 0.1
+L_z_out: 0.010000000000000009
+L_z_in: 0.09
+Partition Nx: 10
+Partition Ny: 10
+Partition Nz: 10
+
+*** MOLECULES ***
+
+MOLECULE: "MT0" Intracellular Number 5 Site_Types 1 Total_Sites 1 Total_Links 0 is2D false
+{
+     TYPE: Name "Site0" Radius 1.00000 D 1.000 Color DARK_GRAY STATES "state0" "state1" 
+
+     SITE 0 : Intracellular : Initial State 'state0'
+          TYPE: Name "Site0" Radius 1.00000 D 1.000 Color DARK_GRAY STATES "state0" "state1" 
+          x 0.00000 y 4.00000 z 4.00000 
+
+
+     Initial_Positions: Random
+}
+
+MOLECULE: "MT1" Intracellular Number 5 Site_Types 2 Total_Sites 2 Total_Links 1 is2D false
+{
+     TYPE: Name "Site0" Radius 1.00000 D 1.000 Color DARK_GRAY STATES "state0" 
+     TYPE: Name "Site1" Radius 1.00000 D 1.000 Color BLUE STATES "state0" 
+
+     SITE 0 : Intracellular : Initial State 'state0'
+          TYPE: Name "Site0" Radius 1.00000 D 1.000 Color DARK_GRAY STATES "state0" 
+          x 0.00000 y 4.00000 z 4.00000 
+     SITE 1 : Intracellular : Initial State 'state0'
+          TYPE: Name "Site1" Radius 1.00000 D 1.000 Color BLUE STATES "state0" 
+          x 0.00000 y 4.00000 z 8.00000 
+
+     LINK: Site 0 ::: Site 1
+
+     Initial_Positions: Random
+}
+
+*** MOLECULE FILES ***
+
+MOLECULE: MT0 null
+MOLECULE: MT1 null
+
+*** CREATION/DECAY REACTIONS ***
+
+'MT0' : kcreate  0.0  kdecay  0.0
+'MT1' : kcreate  0.0  kdecay  0.0
+
+*** STATE TRANSITION REACTIONS ***
+
+'r1' ::     'MT0' : 'Site0' : 'state0' --> 'state1'  Rate 1000.0  Condition Bound 'MT1' : 'Site0' : 'state0'
+
+*** ALLOSTERIC REACTIONS ***
+
+
+*** BIMOLECULAR BINDING REACTIONS ***
+
+'r2'       'MT0' : 'Site0' : 'state0'  +  'MT1' : 'Site0' : 'state0'  kon  25.0  koff 0.0  Bond_Length 1.0
+
+*** MOLECULE COUNTERS ***
+
+'MT0' : Measure Total Free Bound
+'MT1' : Measure Total Free Bound
+
+*** STATE COUNTERS ***
+
+'MT0' : 'Site0' : 'state0' : Measure Total Free Bound
+'MT0' : 'Site0' : 'state1' : Measure Total Free Bound
+'MT1' : 'Site0' : 'state0' : Measure Total Free Bound
+'MT1' : 'Site1' : 'state0' : Measure Total Free Bound
+
+*** BOND COUNTERS ***
+
+'r2' : Counted
+
+*** SITE PROPERTY COUNTERS ***
+
+'MT0' Site 0 : Track Properties true
+'MT1' Site 0 : Track Properties true
+'MT1' Site 1 : Track Properties true
+
+*** CLUSTER COUNTERS ***
+
+Track_Clusters: true
+
+*** SYSTEM ANNOTATIONS ***
+
+
+*** MOLECULE ANNOTATIONS ***
+
+
+*** REACTION ANNOTATIONS ***
+
+


### PR DESCRIPTION
## Problem

When a bound site changes state, `TransitionReactions.updateBondType()` re-derives the bond's properties (reaction name, off-probability, bond length) from the *new* `(siteState, partnerState)` signature by looking them up in the binding-reaction tables. The code assumed that every reachable signature of a bound complex corresponds to some binding reaction. That assumption can be violated, and when it is, the solver throws a `NullPointerException` and the simulation crashes.

### Concrete scenario

- A binding reaction `r1` forms a bond on site `S` of molecule `A`. `r1` is defined for `S` in `state0` (and possibly `state1`).
- Suppose the bond is only *defined* for the `state0` signature.
- A separate state-transition reaction flips `S` from `state0` → `state1` **while the site is bound**.
- After the transition, `updateBondType()` looks up the binding reaction for the new `(state1, partnerState)` signature. None exists, so:
  - `bindingReactions.getName(...)` returns `null` → the bond's reaction name is set to `null`, which later crashes the counter/bond bookkeeping that keys on the reaction name.
  - `bindingReactions.getBondLength(...)` returns `null` → auto-unboxing from `Double` to `double` throws an NPE immediately.

So a perfectly valid model (a conditional bond plus an unconditional state transition on the bound site) crashes the solver.

## Solution

`updateBondType()` now tolerates a transition to a bond signature that has no associated binding reaction, instead of crashing:

- If no binding reaction is found for the new signature, **keep the bond's existing reaction name** (e.g. `r1`) rather than overwriting it with `null`.
- If no bond length is found, **keep the existing bond length** rather than unboxing `null`. To make this possible, `BindingReactions.getBondLength(...)` now returns `Double` (nullable) instead of a primitive `double`.
- The off-probability is still refreshed from the tables. `getOffProb(...)` already returns `0` for an undefined signature, so for the new state the bond's spontaneous break probability becomes `0` — i.e. the bond is effectively held together with a reverse (unbinding) rate of `0.0`.

Net effect: the bond retains its original reaction identity and length, and simply will not spontaneously dissociate while it sits in the undefined state. This matches the intended short-term workaround — "keep the unbinding reaction as `r1` but set its reverse rate to `0.0`."

The same null-guard is applied in both code paths that re-derive a bond's type after a state change: `TransitionReactions.updateBondType()` and `AllostericReactions.updateBondType()`.

## Risk / caveats

This is a workaround, not a physically complete model of the new state, and it has unintended-consequence potential:

- **Bond becomes unbreakable in the undefined state.** With off-probability `0`, a bond that transitions into a signature with no defined reaction can never spontaneously break. If the model author actually intended dissociation to be possible there (but forgot to define it), the bond will persist longer than expected and can bias cluster sizes and steady-state statistics. The crash is replaced by a silent behavioral assumption.
- **Stale reaction identity.** The bond keeps reporting the *old* reaction name (`r1`) even though its current state signature no longer matches `r1`. Any downstream analysis that interprets bond-to-reaction attribution (counters, postprocessing) will attribute these bonds to `r1`, which is technically a lie — chosen deliberately over a null that crashes the counters.
- **Stale bond length.** Keeping the previous bond length is reasonable only if the new state would have used the same geometry; if a different length was intended, the spring rest length is now slightly off.
- **Silent rather than loud.** Because the condition is no longer an error, a genuinely under-specified model (missing reaction) no longer surfaces as a failure. A follow-up could log a one-time warning when this fallback is hit, and the longer-term fix is to let the model define dissociation behavior for every reachable bound-state signature (or explicitly declare a zero off-rate).

## Change summary

- `reaction/TransitionReactions.java` — null-guard the reaction-name and bond-length updates in `updateBondType()`.
- `reaction/AllostericReactions.java` — same null-guard in its `updateBondType()`.
- `reaction/BindingReactions.java` — `getBondLength(...)` returns `Double` (nullable) so callers can detect "no reaction defined" instead of NPE-ing on auto-unboxing.
- `test/.../MySystemTest.java` + `test/resources/TransitionCondBound.ssld` — a regression model (conditional bond + bound-site state transition) that runs a full simulation and previously crashed. The test is disabled on GitHub Actions (`GITHUB_ACTIONS=true`) because it is relatively slow.

This PR is **5 files, +163/−10** over `main` — just the NPE fix and its test.
