### PR TITLE
postprocess: canonicalize the Run-0 site ids file

### DIFF
--- a/src/main/java/edu/uchc/cam/langevin/cli/PostCommand.java
+++ b/src/main/java/edu/uchc/cam/langevin/cli/PostCommand.java
@@ -86,6 +86,7 @@ public class PostCommand implements Callable<Integer> {
         cp.calculateLangevinPrimaryStatistics();
         cp.calculateLangevinAdvancedStatistics();
         cp.canonicalizeTrajectoryFile();    // copy Run-0 viewer file to a flat name for VCell to serve
+        cp.canonicalizeSiteIdsFile();       // ... and the site ids that name each particle in it
 
         modelFile = null;
         return 0;

--- a/src/main/java/edu/uchc/cam/langevin/langevinnovis01/ConsolidationPostprocessor.java
+++ b/src/main/java/edu/uchc/cam/langevin/langevinnovis01/ConsolidationPostprocessor.java
@@ -87,22 +87,48 @@ public class ConsolidationPostprocessor {
     // files land), so copy the viewer file up to a flat name <simulationName>_VIEW_Run0.txt. This
     // is a cheap file copy (no computation); it lets VCell serve the trajectory to the SaLaD 3D
     // renderer. Absence of the viewer file is not an error (e.g. a run that produced no frames).
+    //
+    // Both canonicalize* methods only ADD a file beside the existing outputs — nothing the
+    // standalone SpringSaLaD application reads is moved, renamed or changed.
     public void canonicalizeTrajectoryFile() {
         String viewerFileName = simulationName + "_VIEW_Run0.txt";
         Path source = simulationFolder.toPath()
                 .resolve(simulationName + "_FOLDER")
                 .resolve("viewer_files")
                 .resolve(viewerFileName);
-        Path target = simulationFolder.toPath().resolve(viewerFileName);
+        canonicalize(source, viewerFileName, "trajectory viewer");
+    }
+
+    // The simulate step also writes, for each run, a SiteIDs.csv naming every site it created:
+    //   <simulationName>_FOLDER/data/Run0/SiteIDs.csv
+    // holding "<siteId>,<MoleculeName> Site <n> SiteType <TypeName>" per site (see
+    // MySystem.writeSiteIDs). It is what lets a consumer of the Run-0 trajectory say which molecule
+    // and site each particle is, rather than guessing from its color and radius. Copy it up to a
+    // flat name for the same reason as the viewer file, and additionally because the _FOLDER may be
+    // pruned once a run is archived, which would otherwise lose the names.
+    public void canonicalizeSiteIdsFile() {
+        Path source = simulationFolder.toPath()
+                .resolve(simulationName + "_FOLDER")
+                .resolve("data")
+                .resolve("Run0")
+                .resolve("SiteIDs.csv");
+        canonicalize(source, simulationName + "_SiteIDs_Run0.csv", "site id");
+    }
+
+    // Copy one of the simulate step's subfolder outputs up to a flat, canonically-named file in the
+    // simulation folder. A missing source is not an error: a run may legitimately not have produced
+    // it, and neither file is required for the run's primary results.
+    private void canonicalize(Path source, String targetName, String description) {
+        Path target = simulationFolder.toPath().resolve(targetName);
         if (!Files.exists(source)) {
-            lg.warn("Trajectory viewer file not found, skipping canonicalization: " + source);
+            lg.warn("Run-0 " + description + " file not found, skipping canonicalization: " + source);
             return;
         }
         try {
             Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
-            lg.info("Canonicalized trajectory viewer file to " + target);
+            lg.info("Canonicalized " + description + " file to " + target);
         } catch (IOException e) {
-            lg.warn("Failed to canonicalize trajectory viewer file " + source + " -> " + target, e);
+            lg.warn("Failed to canonicalize " + description + " file " + source + " -> " + target, e);
         }
     }
 

--- a/src/test/java/edu/uchc/cam/langevin/langevinnovis01/CanonicalizeRunFilesTest.java
+++ b/src/test/java/edu/uchc/cam/langevin/langevinnovis01/CanonicalizeRunFilesTest.java
@@ -1,0 +1,200 @@
+package edu.uchc.cam.langevin.langevinnovis01;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.vcell.messaging.VCellMessaging;
+import org.vcell.messaging.VCellMessagingLocal;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * The postprocess step copies two of the simulate step's subfolder outputs up to flat, canonically
+ * named files beside the .ida files: the Run-0 trajectory ("viewer") file, and the SiteIDs.csv that
+ * says which molecule and site each particle in it is.
+ * <p>
+ * This runs a short simulation rather than fabricating the subfolder, so it fails if the layout
+ * MySystem writes to ever moves — otherwise the copy would silently find nothing and skip.
+ */
+public class CanonicalizeRunFilesTest {
+
+    private static final String SIM_NAME = "sim";
+
+    private final String inputFileContents =
+            """
+            Total time: 3.0E-4
+            dt: 1.0E-8
+            dt_data: 1.0E-4
+            dt_spring: 1.0E-9
+            dt_image: 1.0E-4
+
+            *** SYSTEM INFORMATION ***
+            L_x: 0.1
+            L_y: 0.1
+            L_z_out: 0.01
+            L_z_in: 0.09
+            Partition Nx: 10
+            Partition Ny: 10
+            Partition Nz: 10
+
+            *** MOLECULES ***
+
+            MOLECULE: "MT0" Intracellular Number 5 Site_Types 2 Total_Sites 2 Total_Links 1 is2D false
+            {
+                 TYPE: Name "Site0" Radius 1.00000 D 1.000 Color DARK_GRAY STATES "state0"
+                 TYPE: Name "Site1" Radius 1.00000 D 1.000 Color BLUE STATES "state0"
+
+                 SITE 0 : Intracellular : Initial State 'state0'
+                      TYPE: Name "Site0" Radius 1.00000 D 1.000 Color DARK_GRAY STATES "state0"
+                      x 0.00000 y 0.00000 z 0.00000
+                 SITE 1 : Intracellular : Initial State 'state0'
+                      TYPE: Name "Site1" Radius 1.00000 D 1.000 Color BLUE STATES "state0"
+                      x 0.00000 y 0.00000 z 4.00000
+
+                 LINK: Site 0 ::: Site 1
+
+                 Initial_Positions: Random
+            }
+
+            *** MOLECULE FILES ***
+
+            MOLECULE: MT0 null
+
+            *** CREATION/DECAY REACTIONS ***
+
+            'MT0' : kcreate  0  kdecay  0
+
+            *** STATE TRANSITION REACTIONS ***
+
+            *** ALLOSTERIC REACTIONS ***
+
+
+            *** BIMOLECULAR BINDING REACTIONS ***
+
+            *** MOLECULE COUNTERS ***
+
+            'MT0' : Measure Total Free Bound
+
+            *** STATE COUNTERS ***
+
+            'MT0' : 'Site0' : 'state0' : Measure Total Free Bound
+            'MT0' : 'Site1' : 'state0' : Measure Total Free Bound
+
+            *** BOND COUNTERS ***
+
+            *** SITE PROPERTY COUNTERS ***
+
+            'MT0' Site 0 : Track Properties true
+            'MT0' Site 1 : Track Properties true
+
+            *** CLUSTER COUNTERS ***
+
+            Track_Clusters: true
+
+            *** SYSTEM ANNOTATIONS ***
+
+
+            *** MOLECULE ANNOTATIONS ***
+
+
+            *** REACTION ANNOTATIONS ***
+
+
+            *** SIMULATION OPTIONS ***
+
+            RandomSeed: 164200191287356961681
+
+            """;
+
+    @Test
+    public void copiesRunZeroTrajectoryAndSiteIdsToFlatNames() throws IOException {
+        Path tempDirectory = Files.createTempDirectory("test_canonicalize");
+        try {
+            ConsolidationPostprocessor cp = runShortSimulation(tempDirectory);
+
+            Path siteIdsSource = tempDirectory.resolve(SIM_NAME + "_FOLDER")
+                    .resolve("data").resolve("Run0").resolve("SiteIDs.csv");
+            Assertions.assertTrue(Files.exists(siteIdsSource),
+                    "the simulate step should have written " + siteIdsSource);
+
+            cp.canonicalizeTrajectoryFile();
+            cp.canonicalizeSiteIdsFile();
+
+            Path flatViewer = tempDirectory.resolve(SIM_NAME + "_VIEW_Run0.txt");
+            Path flatSiteIds = tempDirectory.resolve(SIM_NAME + "_SiteIDs_Run0.csv");
+            Assertions.assertTrue(Files.exists(flatViewer), "missing " + flatViewer);
+            Assertions.assertTrue(Files.exists(flatSiteIds), "missing " + flatSiteIds);
+            Assertions.assertEquals(Files.readString(siteIdsSource), Files.readString(flatSiteIds),
+                    "the flat copy should be byte-for-byte the original");
+
+            // 5 molecules of 2 sites each, named "<molecule> Site <n> SiteType <type>"
+            String siteIds = Files.readString(flatSiteIds);
+            Assertions.assertEquals(10, siteIds.lines().filter(l -> !l.isBlank()).count());
+            Assertions.assertTrue(siteIds.contains("MT0 Site 0 SiteType Site0"), siteIds);
+            Assertions.assertTrue(siteIds.contains("MT0 Site 1 SiteType Site1"), siteIds);
+        } finally {
+            deleteDirectory(tempDirectory.toFile());
+        }
+    }
+
+    /** Re-running the copy must overwrite rather than fail. */
+    @Test
+    public void canonicalizingTwiceIsHarmless() throws IOException {
+        Path tempDirectory = Files.createTempDirectory("test_canonicalize_twice");
+        try {
+            ConsolidationPostprocessor cp = runShortSimulation(tempDirectory);
+            cp.canonicalizeSiteIdsFile();
+            cp.canonicalizeSiteIdsFile();
+            Assertions.assertTrue(Files.exists(tempDirectory.resolve(SIM_NAME + "_SiteIDs_Run0.csv")));
+        } finally {
+            deleteDirectory(tempDirectory.toFile());
+        }
+    }
+
+    /**
+     * A run that produced no subfolder output must not fail the postprocess — the primary results
+     * are already written by the time these copies happen.
+     */
+    @Test
+    public void missingSourceFilesAreSkippedNotFatal() throws IOException {
+        Path tempDirectory = Files.createTempDirectory("test_canonicalize_missing");
+        try {
+            Path modelFile = tempDirectory.resolve(SIM_NAME + ".langevinInput");
+            Files.writeString(modelFile, inputFileContents);
+            Global g = new Global(modelFile.toFile());
+            ConsolidationPostprocessor cp =
+                    new ConsolidationPostprocessor(g, 1, false, new VCellMessagingLocal());
+
+            // no simulation was run, so neither source exists
+            Assertions.assertDoesNotThrow(cp::canonicalizeTrajectoryFile);
+            Assertions.assertDoesNotThrow(cp::canonicalizeSiteIdsFile);
+            Assertions.assertFalse(Files.exists(tempDirectory.resolve(SIM_NAME + "_VIEW_Run0.txt")));
+            Assertions.assertFalse(Files.exists(tempDirectory.resolve(SIM_NAME + "_SiteIDs_Run0.csv")));
+        } finally {
+            deleteDirectory(tempDirectory.toFile());
+        }
+    }
+
+    private ConsolidationPostprocessor runShortSimulation(Path tempDirectory) throws IOException {
+        Path modelFile = tempDirectory.resolve(SIM_NAME + ".langevinInput");
+        Path logFile = tempDirectory.resolve(SIM_NAME + ".log");
+        Files.writeString(modelFile, inputFileContents);
+
+        VCellMessaging vcellMessaging = new VCellMessagingLocal();
+        Global g = new Global(modelFile.toFile(), logFile.toFile());
+        new MySystem(g, 0, true, vcellMessaging).runSystem();
+        return new ConsolidationPostprocessor(g, 1, true, vcellMessaging);
+    }
+
+    private void deleteDirectory(File directoryToBeDeleted) {
+        File[] allContents = directoryToBeDeleted.listFiles();
+        if (allContents != null) {
+            for (File file : allContents) {
+                deleteDirectory(file);
+            }
+        }
+        directoryToBeDeleted.delete();
+    }
+}


### PR DESCRIPTION
## What

The simulate step already writes, per run, a `SiteIDs.csv` naming every site it created:

```
100000000,MT0 Site 0 SiteType Site0
```

This copies it up to a flat `<simulationName>_SiteIDs_Run0.csv`, exactly as
`canonicalizeTrajectoryFile()` already does for the Run-0 viewer file, and factors the
shared copy out of the two methods.

## Why

That file is what lets a consumer of the Run-0 trajectory say which molecule and site
each particle is, instead of inferring it from the particle's color and radius. Colors
alone are not enough: in this repo's own `all_reactions` test case, `MT0` and `MT1` both
have a `DARK_GRAY` r=1 site and a `BLUE` r=1 site, so a color-based grouping merges two
distinct species.

It currently lands in `<simulationName>_FOLDER/data/Run0/`. VCell only discovers flat,
canonically-named files directly in the user dir, and that subfolder is pruned once a
run is archived — which would lose the names for older runs.

## Compatibility

Both `canonicalize*` methods only **add** a file beside the existing outputs. No existing
file is moved, renamed or changed, so the standalone SpringSaLaD application that shares
this solver is unaffected. A missing source stays a warning rather than an error, since
the run's primary results are already written by the time these copies happen.

The flat name is a contract with VCell's `LangevinFileType.SiteIds` — if the two drift
apart the file is simply never found and sites go quietly unnamed, with no error
anywhere, so the VCell side pins the expected name in a test.

## Testing

New `CanonicalizeRunFilesTest` (3 tests) runs a short simulation rather than fabricating
the subfolder, so it fails if the layout `MySystem` writes to ever moves — otherwise the
copy would silently find nothing and skip. It also covers re-running the copy and the
missing-source case.

`mvn test` is 26/27 passing. `ClusterAnalisysTest.testAllReactions` fails identically on
a pristine `main` (verified against a throwaway worktree), so it is pre-existing and
unrelated.

## Companion

VCell reads this file and returns it with the trajectory: virtualcell/vcell#1814.
VCell already falls back to the `_FOLDER` subfolder, so nothing breaks before this ships;
merging it is what makes archived and pruned runs keep their names.

Once merged this needs a LangevinNoVis01 release, then a bump of the three
`solvers-langevin-{mac,windows,linux}.version` properties in VCell's root `pom.xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvqmME7MkRUNEYje5HpiLt